### PR TITLE
Set license according to bower spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,12 +11,7 @@
         "type": "git",
         "url": "https://github.com/s-yadav/angulargrid"
     },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/s-yadav/angulargrid/blob/master/MIT-LICENSE.txt"
-        }
-    ],
+    "license": "MIT",
     "bugs": {
         "url": "https://github.com/s-yadav/angulargrid/issues"
     },


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#license

I need this to be able to upload the bower package as a webjar