### PR TITLE
Add ignore key to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,11 @@
     "dependencies": {
         "angular": ">=1.3.0"
     },
+    "ignore": [
+        "*.md",
+        "demo",
+        "MIT-LICENSE.txt"
+    ],
     "keywords": [
         "angular-grid",
         "masonry-grid",


### PR DESCRIPTION
Helps to keep bower packages smaller and removes this warning:

```
bower invalid-meta  angulargrid is missing "ignore" entry in bower.json
```

https://github.com/bower/spec/blob/master/json.md#ignore