### PR TITLE
Revert "Issue #72: When specifying a scroll container by utilizing CSS class …"

### DIFF
--- a/angulargrid.js
+++ b/angulargrid.js
@@ -109,7 +109,7 @@
             agId: '@',
             pageSize: '=agPageSize',
             performantScroll: '=agPerformantScroll',
-            scrollContainer: '@agScrollContainer',
+            scrollContainer: '=agScrollContainer',
             infiniteScroll: '&agInfiniteScroll',
             infiniteScrollDistance: '=agInfiniteScrollDistance',
             infiniteScrollDelay: '=agInfiniteScrollDelay'


### PR DESCRIPTION
This is meant to be evaluated as expression, so that it can come from scope variable.
If you need to define css selector directly you can add it within an extra qoute.

```html
<ul class="dynamic-grid" angular-grid="pics" ag-grid-width="300" ag-gutter-size="10" ag-id="gallery" ag-scroll-container=" '#gallery-wrap' " ag-infinite-scroll="loadMore()" >
     ....
</ul>
```

It seems I have mentioned it wrong on docs, will fix that.

Reverts s-yadav/angulargrid#73