### PR TITLE
Remove clones anyway

### DIFF
--- a/angulargrid.js
+++ b/angulargrid.js
@@ -455,7 +455,10 @@
                   },
                   onFullLoad: function() {
                     //if its older reflow don't do any thing
-                    if (reflowIndx < reflowCount) return;
+                    if (reflowIndx < reflowCount) {
+                      clones.remove();
+                      return;
+                    }
 
                     var listElmHeights = [],
                       listElmPosInfo = [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angulargrid",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pinterest like responsive masonry grid system for angular.",
   "keywords": [
     "angular-grid",


### PR DESCRIPTION
I realized on IE11 and Edge that many clones will be appended to the container but not removed.
This issue happens because of different timings of image load on Microsoft browsers. But any way, you prevent reflow if reflowIndex is smaller than relfowCount. This is a fine optimization but you should remove appended clones, anyway.

Would you like to review my pull request?