### PR TITLE
Fixed issue #62: Infinite scroll in IE.

### DIFF
--- a/angulargrid.js
+++ b/angulargrid.js
@@ -313,7 +313,7 @@
 
             //scroll event on scroll container element to refresh dom depending on scroll positions
             function scrollHandler() {
-              var scrollTop = this.scrollTop || this.scrollY;
+              var scrollTop = this.scrollTop || this.pageYOffset || this.scrollY;
               if (options.performantScroll) refreshDomElm(scrollTop);
               if (scope.infiniteScroll) infiniteScroll(scrollTop);
             }


### PR DESCRIPTION
Infinite scrolling does not work in Internet Explorer, tested on version 11.

The current scrollTop handling gives undefined on IE.

This little change fixes infinite scrolling on IE, as reported in issue #62 , and I happened to run into it by chance also.

I haven't run a minifier for this change yet, which is something you might want to do.