### PR TITLE
Fixed potential access to undefined

### DIFF
--- a/angulargrid.js
+++ b/angulargrid.js
@@ -299,7 +299,7 @@
             }
 
             function infiniteScroll(scrollTop) {
-              if (scrollNs.isLoading || !scope.model.length) return;
+              if (scrollNs.isLoading || !scope.model || !scope.model.length) return;
               var scrollHeight = scrollNs.scrollContInfo.scrollHeight,
                 contHeight = scrollNs.scrollContInfo.height;
 


### PR DESCRIPTION
If you read data passed to the angularGrid through the network, model could be undefined and throw an error when accessing length. I have added additional check that scope.model is defined.